### PR TITLE
Fix favicon paths in recipe pages

### DIFF
--- a/baguette.html
+++ b/baguette.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Baguette</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/bollo.html
+++ b/bollo.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Bollo</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/brioche.html
+++ b/brioche.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Brioche</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/croissant.html
+++ b/croissant.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Croissant</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/hamburguesa.html
+++ b/hamburguesa.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Hamburguesa</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/hogaza.html
+++ b/hogaza.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Receta: Hogaza</title>
 
-  <link rel="icon" href="../img/favicon.png" type="image/png" />
+  <link rel="icon" href="./img/favicon.png" type="image/png" />
 
   <!-- Bootstrap -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- fix favicon link paths in baguette, brioche, bollo, croissant, hamburguesa, and hogaza recipe pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951b1379108325b3a6841f0f99e68e