### PR TITLE
Add poster images for recipe videos

### DIFF
--- a/baguette-multigrano.html
+++ b/baguette-multigrano.html
@@ -32,7 +32,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/Baguette-Multigrano.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/Baguette-Multigrano.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>

--- a/croissant.html
+++ b/croissant.html
@@ -32,7 +32,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/Croissant.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/Croissant.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>

--- a/hogaza-de-masa-madre.html
+++ b/hogaza-de-masa-madre.html
@@ -31,7 +31,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/1.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/1.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>

--- a/pan-bollo.html
+++ b/pan-bollo.html
@@ -32,7 +32,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/bollo.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/bollo.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>

--- a/pan-brioche-bread.html
+++ b/pan-brioche-bread.html
@@ -32,7 +32,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/Pan-Brioche-Bread.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/Pan-Brioche-Bread.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>

--- a/pan-de-hamburguesa.html
+++ b/pan-de-hamburguesa.html
@@ -32,7 +32,7 @@
 
       <!-- Video -->
       <div class="col-12 col-lg-6 mb-4 mb-lg-0 d-flex justify-content-center">
-        <video src="./video/Hamburguesa.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
+        <video poster="./img/logo.jpg" src="./video/Hamburguesa.mp4" controls class="rounded shadow-sm w-100" style="max-width: 360px;">
           Tu navegador no soporta el video HTML5.
         </video>
       </div>


### PR DESCRIPTION
## Summary
- show logo as a cover image for each recipe video using the `poster` attribute

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33ed014c88325b2d637e872d8e74b