### PR TITLE
feat: enable lazy loading for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <div class="container py-5 text-center">
     <div class="d-flex flex-column align-items-center">
       <h1 class="main-title">Recetas</h1>
-      <img src="./img/logo-horizontal.png" alt="Logo Tartaleta" class="img-fluid" style="max-width: 50%;">
+      <img loading="lazy" src="./img/logo-horizontal.png" alt="Logo Tartaleta" class="img-fluid" style="max-width: 50%;">
     </div>
   </div>
 
@@ -36,7 +36,7 @@
       <div class="col-6 col-lg-4">
         <a href="hogaza-de-masa-madre.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/hogaza-de-masa-madre.png" alt="Hogaza">
+            <img loading="lazy" src="./img/hogaza-de-masa-madre.png" alt="Hogaza">
             <div class="card-body">
               <h5 class="card-title">Hogaza de Masa Madre</h5>
             </div>
@@ -48,7 +48,7 @@
       <div class="col-6 col-lg-4">
         <a href="baguette-multigrano.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/baguette-multigrano.png" alt="Baguette">
+            <img loading="lazy" src="./img/baguette-multigrano.png" alt="Baguette">
             <div class="card-body">
               <h5 class="card-title">Baguette Multigrano</h5>
             </div>
@@ -60,7 +60,7 @@
       <div class="col-6 col-lg-4">
         <a href="baguette-mantequilla.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/baguette-mantequilla.png" alt="Baguette">
+            <img loading="lazy" src="./img/baguette-mantequilla.png" alt="Baguette">
             <div class="card-body">
               <h5 class="card-title">Baguette Mantequilla</h5>
             </div>
@@ -72,7 +72,7 @@
       <div class="col-6 col-lg-4">
         <a href="pan-de-hamburguesa.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/pan-de-hamburguesa.png" alt="Hamburguesa">
+            <img loading="lazy" src="./img/pan-de-hamburguesa.png" alt="Hamburguesa">
             <div class="card-body">
               <h5 class="card-title">Pan de Hamburguesa</h5>
             </div>
@@ -84,7 +84,7 @@
       <div class="col-6 col-lg-4">
         <a href="croissant.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/croissant.png" alt="Croissant">
+            <img loading="lazy" src="./img/croissant.png" alt="Croissant">
             <div class="card-body">
               <h5 class="card-title">Croissant</h5>
             </div>
@@ -96,7 +96,7 @@
       <div class="col-6 col-lg-4">
         <a href="pan-brioche-bread.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/brioche.png" alt="Brioche">
+            <img loading="lazy" src="./img/brioche.png" alt="Brioche">
             <div class="card-body">
               <h5 class="card-title">Brioche</h5>
             </div>
@@ -108,7 +108,7 @@
       <div class="col-6 col-lg-4">
         <a href="pan-bollo.html" class="text-decoration-none">
           <div class="card card-tartaleta">
-            <img src="./img/pan-bollo.png" alt="Bollo">
+            <img loading="lazy" src="./img/pan-bollo.png" alt="Bollo">
             <div class="card-body">
               <h5 class="card-title">Pan Bollo</h5>
             </div>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to all homepage images to optimize load times

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a367d47fb48325864f96fe6dc0c97e