### PR TITLE
Hide decorative icons from screen readers

### DIFF
--- a/baguette-mantequilla.html
+++ b/baguette-mantequilla.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -57,7 +57,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -68,7 +68,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes</li>
@@ -79,7 +79,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -87,7 +87,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Sándwich saludable</li>
@@ -99,7 +99,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello de masa madre<br>
@@ -113,7 +113,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/baguette-multigrano.html
+++ b/baguette-multigrano.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -62,7 +62,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -73,7 +73,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -84,7 +84,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -92,7 +92,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Sándwich saludable (pollo, pavo o atún)</li>
@@ -104,7 +104,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello de masa madre<br>
@@ -118,7 +118,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/croissant.html
+++ b/croissant.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -59,7 +59,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -70,7 +70,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -81,7 +81,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -89,7 +89,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Croissant relleno</li>
@@ -101,7 +101,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello “Disfruta en casa”<br>
@@ -115,7 +115,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/hogaza-de-masa-madre.html
+++ b/hogaza-de-masa-madre.html
@@ -42,7 +42,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -55,7 +55,7 @@
         <!-- Procedimiento -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-list-ol fa-xs me-2"></i>Procedimiento
+            <span class="fas fa-list-ol fa-xs me-2" aria-hidden="true"></span>Procedimiento
           </h2>
           <ol class="receta-text">
             <li>Mezclar todos los ingredientes hasta obtener una masa homogénea.</li>
@@ -68,7 +68,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -79,7 +79,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -90,7 +90,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -98,7 +98,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Tostadas</li>
@@ -110,7 +110,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello de masa madre<br>
@@ -124,7 +124,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/pan-bollo.html
+++ b/pan-bollo.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -56,7 +56,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -67,7 +67,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -78,7 +78,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -86,7 +86,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Loncheras escolares</li>
@@ -97,7 +97,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello de masa madre<br>
@@ -111,7 +111,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/pan-brioche-bread.html
+++ b/pan-brioche-bread.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -56,7 +56,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -67,7 +67,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -78,7 +78,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -86,7 +86,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>French toast (miel, frutas y canela)</li>
@@ -98,7 +98,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello “Disfruta en casa”<br>
@@ -112,7 +112,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 

--- a/pan-de-hamburguesa.html
+++ b/pan-de-hamburguesa.html
@@ -43,7 +43,7 @@
         <!-- Ingredientes -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-carrot fa-xs me-2"></i>Ingredientes
+            <span class="fas fa-carrot fa-xs me-2" aria-hidden="true"></span>Ingredientes
           </h2>
           <ul class="receta-text">
             <li>Harina de trigo</li>
@@ -59,7 +59,7 @@
         <!-- Vida útil y almacenamiento -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-clock fa-xs me-2"></i>Vida útil y almacenamiento
+            <span class="fas fa-clock fa-xs me-2" aria-hidden="true"></span>Vida útil y almacenamiento
           </h2>
           <ul class="receta-text">
             <li>Temperatura ambiente: 3 días</li>
@@ -70,7 +70,7 @@
         <!-- Reactivar -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-sync-alt fa-xs me-2"></i>Reactivar
+            <span class="fas fa-sync-alt fa-xs me-2" aria-hidden="true"></span>Reactivar
           </h2>
           <ul class="receta-text">
             <li>Sacar del congelador 1 hora antes de consumir.</li>
@@ -81,7 +81,7 @@
         <!-- Alérgenos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-exclamation-triangle fa-xs me-2"></i>Alérgenos
+            <span class="fas fa-exclamation-triangle fa-xs me-2" aria-hidden="true"></span>Alérgenos
           </h2>
           <p class="receta-text">Contiene gluten, lácteos, huevo, semillas y nueces.</p>
         </div>
@@ -89,7 +89,7 @@
         <!-- Usos sugeridos -->
         <div class="mb-4">
           <h2 class="receta-section-title">
-            <i class="fas fa-utensils fa-xs me-2"></i>Usos sugeridos
+            <span class="fas fa-utensils fa-xs me-2" aria-hidden="true"></span>Usos sugeridos
           </h2>
           <ul class="receta-text">
             <li>Hamburguesa de carne, pollo o tocino</li>
@@ -99,7 +99,7 @@
         <!-- Empaque -->
         <div>
           <h2 class="receta-section-title">
-            <i class="fas fa-box-open fa-xs me-2"></i>Empaque
+            <span class="fas fa-box-open fa-xs me-2" aria-hidden="true"></span>Empaque
           </h2>
           <p class="receta-text">
             Bolsa con sello “Disfruta en casa”<br>
@@ -113,7 +113,7 @@
     <!-- Botón volver -->
     <footer class="text-center">
       <a href="index.html" class="btn btn-volver">
-        <i class="fas fa-arrow-left me-2"></i>Elegir otra receta
+        <span class="fas fa-arrow-left me-2" aria-hidden="true"></span>Elegir otra receta
       </a>
     </footer>
 


### PR DESCRIPTION
## Summary
- Replace Font Awesome `<i>` icons with `<span aria-hidden="true">` across recipe pages for better accessibility.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a367e42a148325aadf8f558a56df97